### PR TITLE
Implemented Floyd Warshall Algorithm with Use-Case Modifications

### DIFF
--- a/CropOptimaProject/main.cpp
+++ b/CropOptimaProject/main.cpp
@@ -11,14 +11,14 @@ int main() {
     //loading crop data based on the specified state
     vector<Crop> crops = readStateCropData("../CropOptimaProject/dataset/cropNutrientDataset.csv", state);
 
-    vector<Crop> newCrops;
+    //vector<Crop> newCrops;
 
-    for(int i = 0; i < 4; i++) {
-        newCrops.push_back(crops[i]);
-    }
+//    for(int i = 0; i < 300; i++) {
+//        newCrops.push_back(crops[i]);
+//    }
 
     // create the graph based on how many crops are in the specified state
-    Graph cropGraph(newCrops);
+    Graph cropGraph(crops);
 
     // populate the graph with the proper compatibility values (edge weights)
     cropGraph.populate();
@@ -27,11 +27,15 @@ int main() {
     cropGraph.printMatrix();
 
     //get user input for the starting and ending crop for the rotation
-    string startCrop = "Breadfruit Tree";
-    string endCrop = "Ambrosia";
+    string startCrop = "Apricot";
+    string endCrop = "Almond";
 
     //running the algorithms
     cropGraph.bellmanFord(startCrop, endCrop);
+    cout << "" << endl;
+    cout << "" << endl;
+    cout << "" << endl;
+    cropGraph.floydWarshall(startCrop, endCrop);
 
     return 0;
 


### PR DESCRIPTION
In this commit I implemented the Floyd Warshall algorithm for(as we discovered) its ability to use negative weights, detect cycles, and use (user inputted) start and end crops - comparable to Bellman Ford.

This implementation includes modifications to adapt it to crop sequence optimization based on NPK nutrient values. So for example it uses a nutrient-based (tuple) distance matrix instead of relying on a single weight value. @isabellabonilla 's Bellman Ford algorithm implementation followed this same idea and provided the matrix structure for this algorithm. My FW algorithm also has a custom relaxation condition using sum of absolute nutrient differences and uses a 'next' matrix as suggested by documentation and sources in order to reconstruct the optimal path. IF path reconstruction fails due to cycle, sources suggested a fallback greedy approach to complete the sequence. Even with this fallback, FW algorithm maintains its integrity and validity - please reach out to me for more specification.

A major bug fix throughout this implementation was when the sequence encountered a cycle. There is a check in the code to handle and reroute after a cycle to prevent infinite loops in our desired crop rotation. I have tested extensively but @isabellabonilla please reach out to me if there happens to be any related issues!

I did my best to follow @isabellabonilla 's coding style and loop/output style to maintain clean working style, but feel free to modify this code to follow more readable or strict conventions!